### PR TITLE
Hotfix/reload historical average

### DIFF
--- a/edgemanage/edgestate.py
+++ b/edgemanage/edgestate.py
@@ -198,7 +198,7 @@ class EdgeState(object):
             if len(self.historical_average) > FETCH_HISTORY:
                 min_value = sorted(self.historical_average.keys())[0]
                 del(self.historical_average[min_value])
-            self.historical_average[the_time] = self.current_average()
+            self.historical_average[str(the_time)] = self.current_average()
 
         self._dump()
         return the_time

--- a/tests/test_edgestate.py
+++ b/tests/test_edgestate.py
@@ -19,10 +19,17 @@ class EdgeStateTemplate(unittest.TestCase):
     """
     Sub-classable test to handle state file generation and cleanup
     """
+
     def _make_store(self):
         self.store_dir = tempfile.mkdtemp()
         a = edgemanage.edgestate.EdgeState(TEST_EDGE, self.store_dir)
         return a
+
+    def _reopen_store(self, edgename, store_dir=None):
+        if not store_dir:
+            store_dir = self.store_dir
+        b = edgemanage.edgestate.EdgeState(edgename, store_dir)
+        return b
 
     def tearDown(self):
         shutil.rmtree(self.store_dir)

--- a/tests/test_edgestate.py
+++ b/tests/test_edgestate.py
@@ -67,6 +67,25 @@ class EdgeStateTest(EdgeStateTemplate):
 
         self.assertEqual(len(a.historical_average), TEST_FETCH_HISTORY + 1)
 
+    def testHistoricalAverageRotationAfterReloadingTheStateFile(self):
+        """
+        This test detects serialization issues when the rotation of
+        historical average records is performed on reloaded files
+        """
+
+        a = self._make_store()
+        minute_zero_ts = 1645210800  # 2022-02-18 19:00:00 UTC
+
+        for i in range(TEST_FETCH_HISTORY * 2):
+            a.add_value(2, timestamp=(minute_zero_ts + i / 100))
+
+        b = self._reopen_store(a.edgename)
+        minute_zero_ts = minute_zero_ts + 3600  # 2022-02-18 20:00:00 UTC
+        for i in range(TEST_FETCH_HISTORY * 2):
+            b.add_value(2, timestamp=(minute_zero_ts + i / 100))
+
+        self.assertEqual(len(b.historical_average), TEST_FETCH_HISTORY + 1)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_edgestate.py
+++ b/tests/test_edgestate.py
@@ -56,6 +56,17 @@ class EdgeStateTest(EdgeStateTemplate):
 
         self.assertEqual(len(a), TEST_FETCH_HISTORY)
 
+    def testHistoricalAverageRotation(self):
+        a = self._make_store()
+
+        # A fixed datetime with minutes in zero is used to force the rotation
+        minute_zero_ts = 1645210800  # 2022-02-18 19:00:00 UTC
+
+        for i in range(TEST_FETCH_HISTORY * 2):
+            a.add_value(2, timestamp=(minute_zero_ts + i / 100))
+
+        self.assertEqual(len(a.historical_average), TEST_FETCH_HISTORY + 1)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_edgestate.py
+++ b/tests/test_edgestate.py
@@ -50,7 +50,7 @@ class EdgeStateTest(EdgeStateTemplate):
     def testStoreRotation(self):
         a = self._make_store()
 
-        for i in range(TEST_FETCH_HISTORY+1):
+        for i in range(TEST_FETCH_HISTORY + 1):
             a.add_value(2)
             time.sleep(0.01)
 
@@ -87,5 +87,5 @@ class EdgeStateTest(EdgeStateTemplate):
         self.assertEqual(len(b.historical_average), TEST_FETCH_HISTORY + 1)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
This patch fixes an issue that happens when the historical_average records are created after restarting the edgemanage services.